### PR TITLE
[feat] 도시 카드 클릭 시 이동할 상세 페이지 구현 (#1)

### DIFF
--- a/src/app/(main)/cities/[id]/page.tsx
+++ b/src/app/(main)/cities/[id]/page.tsx
@@ -1,0 +1,55 @@
+import { notFound } from "next/navigation"
+import type { Metadata } from "next"
+import { cities } from "@/data/cities"
+import CityDetailHero from "@/components/city-detail/CityDetailHero"
+import CityInfoGrid from "@/components/city-detail/CityInfoGrid"
+import CityTagList from "@/components/city-detail/CityTagList"
+import CityScoreBar from "@/components/city-detail/CityScoreBar"
+import RelatedCities from "@/components/city-detail/RelatedCities"
+
+type Props = {
+  params: Promise<{ id: string }>
+}
+
+export function generateStaticParams() {
+  return cities.map((city) => ({ id: city.id }))
+}
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { id } = await params
+  const city = cities.find((c) => c.id === id)
+  if (!city) return {}
+  return {
+    title: `${city.name} | K·NOMADS`,
+    description: `${city.name} 디지털 노마드 정보 — 예산 ${city.budget}, ${city.region}`,
+  }
+}
+
+export default async function CityDetailPage({ params }: Props) {
+  const { id } = await params
+  const city = cities.find((c) => c.id === id)
+
+  if (!city) notFound()
+
+  return (
+    <div className="min-h-screen bg-slate-50">
+      {/* Hero */}
+      <CityDetailHero city={city} />
+
+      {/* 본문 */}
+      <div className="max-w-2xl mx-auto px-4 py-6 space-y-5">
+        {/* 핵심 정보 그리드 */}
+        <CityInfoGrid city={city} />
+
+        {/* 태그 */}
+        <CityTagList city={city} />
+
+        {/* 좋아요 비율 */}
+        <CityScoreBar city={city} />
+
+        {/* 같은 지역 추천 */}
+        <RelatedCities city={city} />
+      </div>
+    </div>
+  )
+}

--- a/src/components/city-detail/CityDetailHero.tsx
+++ b/src/components/city-detail/CityDetailHero.tsx
@@ -1,0 +1,49 @@
+import Link from "next/link"
+import { ArrowLeft } from "lucide-react"
+import type { City } from "@/data/cities"
+
+type Props = {
+  city: City
+}
+
+export default function CityDetailHero({ city }: Props) {
+  return (
+    <div className="relative h-64 bg-gradient-to-br from-emerald-400 to-slate-600 overflow-hidden">
+      {/* 배경 텍스처 */}
+      <div className="absolute inset-0 bg-gradient-to-br from-emerald-500/60 via-slate-500/40 to-slate-700/80" />
+
+      {/* 도시 이니셜 */}
+      <div className="absolute inset-0 flex items-center justify-center">
+        <span className="text-white/10 text-[160px] font-black select-none leading-none">
+          {city.name.charAt(0)}
+        </span>
+      </div>
+
+      {/* 뒤로가기 */}
+      <div className="absolute top-4 left-4 z-10">
+        <Link
+          href="/"
+          className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full bg-black/30 text-white text-sm font-medium hover:bg-black/50 transition-colors backdrop-blur-sm"
+        >
+          <ArrowLeft className="h-4 w-4" />
+          목록으로
+        </Link>
+      </div>
+
+      {/* 배지 */}
+      {city.badge && (
+        <div className="absolute top-4 right-4 z-10">
+          <span className="px-3 py-1 rounded-full bg-emerald-500 text-white text-xs font-bold shadow">
+            {city.badge}
+          </span>
+        </div>
+      )}
+
+      {/* 도시명 + 지역 */}
+      <div className="absolute bottom-5 left-5 z-10">
+        <p className="text-emerald-200 text-sm font-medium mb-0.5">{city.region}</p>
+        <h1 className="text-white text-3xl font-black">{city.name}</h1>
+      </div>
+    </div>
+  )
+}

--- a/src/components/city-detail/CityInfoGrid.tsx
+++ b/src/components/city-detail/CityInfoGrid.tsx
@@ -1,0 +1,69 @@
+import { Wallet, MapPin, Monitor, Sun } from "lucide-react"
+import { Badge } from "@/components/ui/badge"
+import type { City } from "@/data/cities"
+
+type Props = {
+  city: City
+}
+
+export default function CityInfoGrid({ city }: Props) {
+  return (
+    <div className="grid grid-cols-2 gap-3">
+      {/* 예산 */}
+      <div className="bg-white rounded-xl border border-slate-100 p-4 shadow-sm">
+        <div className="flex items-center gap-2 mb-2">
+          <Wallet className="h-4 w-4 text-emerald-500" />
+          <span className="text-xs font-medium text-slate-500">월 예산</span>
+        </div>
+        <p className="text-sm font-bold text-slate-800">{city.budget}</p>
+      </div>
+
+      {/* 지역 */}
+      <div className="bg-white rounded-xl border border-slate-100 p-4 shadow-sm">
+        <div className="flex items-center gap-2 mb-2">
+          <MapPin className="h-4 w-4 text-emerald-500" />
+          <span className="text-xs font-medium text-slate-500">지역</span>
+        </div>
+        <p className="text-sm font-bold text-slate-800">{city.region}</p>
+      </div>
+
+      {/* 작업 환경 */}
+      <div className="bg-white rounded-xl border border-slate-100 p-4 shadow-sm">
+        <div className="flex items-center gap-2 mb-2">
+          <Monitor className="h-4 w-4 text-emerald-500" />
+          <span className="text-xs font-medium text-slate-500">작업 환경</span>
+        </div>
+        <div className="flex flex-wrap gap-1">
+          {city.environment.map((env) => (
+            <Badge
+              key={env}
+              variant="secondary"
+              className="text-[11px] px-2 py-0.5 bg-emerald-50 text-emerald-700 border-emerald-100"
+            >
+              {env}
+            </Badge>
+          ))}
+        </div>
+      </div>
+
+      {/* 추천 계절 */}
+      <div className="bg-white rounded-xl border border-slate-100 p-4 shadow-sm">
+        <div className="flex items-center gap-2 mb-2">
+          <Sun className="h-4 w-4 text-emerald-500" />
+          <span className="text-xs font-medium text-slate-500">추천 계절</span>
+        </div>
+        <div className="flex flex-wrap gap-1">
+          {city.bestSeason.map((season) => (
+            <Badge
+              key={season}
+              variant="secondary"
+              className="text-[11px] px-2 py-0.5 bg-amber-50 text-amber-700 border-amber-100"
+            >
+              {season}
+            </Badge>
+          ))}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/components/city-detail/CityScoreBar.tsx
+++ b/src/components/city-detail/CityScoreBar.tsx
@@ -1,0 +1,39 @@
+import { ThumbsUp, ThumbsDown } from "lucide-react"
+import type { City } from "@/data/cities"
+
+type Props = {
+  city: City
+}
+
+export default function CityScoreBar({ city }: Props) {
+  const total = city.likes + city.dislikes
+  const likePercent = total > 0 ? Math.round((city.likes / total) * 100) : 0
+
+  return (
+    <div className="bg-white rounded-xl border border-slate-100 p-5 shadow-sm">
+      <h2 className="text-sm font-semibold text-slate-700 mb-3">노마드 평가</h2>
+
+      {/* 비율 바 */}
+      <div className="h-3 rounded-full bg-slate-100 overflow-hidden mb-3">
+        <div
+          className="h-full rounded-full bg-emerald-500 transition-all"
+          style={{ width: `${likePercent}%` }}
+        />
+      </div>
+
+      {/* 수치 */}
+      <div className="flex items-center justify-between text-sm">
+        <div className="flex items-center gap-1.5 text-emerald-600">
+          <ThumbsUp className="h-4 w-4 fill-emerald-500 text-emerald-500" />
+          <span className="font-bold">{city.likes}</span>
+          <span className="text-slate-400 text-xs">({likePercent}%)</span>
+        </div>
+        <div className="flex items-center gap-1.5 text-rose-500">
+          <ThumbsDown className="h-4 w-4 fill-rose-400 text-rose-400" />
+          <span className="font-bold">{city.dislikes}</span>
+          <span className="text-slate-400 text-xs">({100 - likePercent}%)</span>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/components/city-detail/CityTagList.tsx
+++ b/src/components/city-detail/CityTagList.tsx
@@ -1,0 +1,27 @@
+import { Tag } from "lucide-react"
+import type { City } from "@/data/cities"
+
+type Props = {
+  city: City
+}
+
+export default function CityTagList({ city }: Props) {
+  return (
+    <div className="bg-white rounded-xl border border-slate-100 p-5 shadow-sm">
+      <div className="flex items-center gap-2 mb-3">
+        <Tag className="h-4 w-4 text-emerald-500" />
+        <h2 className="text-sm font-semibold text-slate-700">이 도시의 특징</h2>
+      </div>
+      <div className="flex flex-wrap gap-2">
+        {city.tags.map((tag) => (
+          <span
+            key={tag}
+            className="px-3 py-1 rounded-full bg-slate-100 text-slate-600 text-sm font-medium hover:bg-emerald-50 hover:text-emerald-700 transition-colors"
+          >
+            #{tag}
+          </span>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/src/components/city-detail/RelatedCities.tsx
+++ b/src/components/city-detail/RelatedCities.tsx
@@ -1,0 +1,44 @@
+import Link from "next/link"
+import { cities } from "@/data/cities"
+import type { City } from "@/data/cities"
+
+type Props = {
+  city: City
+}
+
+export default function RelatedCities({ city }: Props) {
+  const related = cities
+    .filter((c) => c.region === city.region && c.id !== city.id)
+    .slice(0, 3)
+
+  if (related.length === 0) return null
+
+  return (
+    <section>
+      <h2 className="text-base font-bold text-slate-800 mb-3">
+        {city.region} 다른 도시
+      </h2>
+      <div className="grid grid-cols-3 gap-3">
+        {related.map((c) => (
+          <Link
+            key={c.id}
+            href={`/cities/${c.id}`}
+            className="bg-white rounded-xl border border-slate-100 p-3 shadow-sm hover:shadow-md hover:border-emerald-200 transition-all"
+          >
+            {/* 미니 이미지 */}
+            <div className="relative h-16 rounded-lg bg-gradient-to-br from-emerald-200/60 to-slate-400 overflow-hidden mb-2 flex items-center justify-center">
+              <span className="text-white/50 text-xl font-black">{c.name.charAt(0)}</span>
+              {c.badge && (
+                <span className="absolute top-1 left-1 px-1.5 py-0 rounded-full bg-emerald-500 text-white text-[9px] font-bold">
+                  {c.badge}
+                </span>
+              )}
+            </div>
+            <p className="text-xs font-bold text-slate-800 truncate">{c.name}</p>
+            <p className="text-[11px] text-slate-400 mt-0.5">{c.budget}</p>
+          </Link>
+        ))}
+      </div>
+    </section>
+  )
+}

--- a/src/components/home/CityCard.tsx
+++ b/src/components/home/CityCard.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import { useState } from "react"
+import Link from "next/link"
 import { ThumbsUp, ThumbsDown } from "lucide-react"
 import { Badge } from "@/components/ui/badge"
 import { cn } from "@/lib/utils"
@@ -16,7 +17,8 @@ export default function CityCard({ city }: CityCardProps) {
   const [likeCount, setLikeCount] = useState(city.likes)
   const [dislikeCount, setDislikeCount] = useState(city.dislikes)
 
-  const handleLike = () => {
+  const handleLike = (e: React.MouseEvent) => {
+    e.stopPropagation()
     if (liked) {
       setLiked(false)
       setLikeCount((c) => c - 1)
@@ -30,7 +32,8 @@ export default function CityCard({ city }: CityCardProps) {
     }
   }
 
-  const handleDislike = () => {
+  const handleDislike = (e: React.MouseEvent) => {
+    e.stopPropagation()
     if (disliked) {
       setDisliked(false)
       setDislikeCount((c) => c - 1)
@@ -45,7 +48,7 @@ export default function CityCard({ city }: CityCardProps) {
   }
 
   return (
-    <div className="rounded-xl border border-slate-200 bg-white overflow-hidden shadow-sm hover:shadow-md transition-shadow">
+    <Link href={`/cities/${city.id}`} className="block rounded-xl border border-slate-200 bg-white overflow-hidden shadow-sm hover:shadow-md transition-shadow">
       {/* 이미지 영역 */}
       <div className="relative h-44 bg-gradient-to-br from-slate-300 to-slate-400 overflow-hidden">
         <div className="absolute inset-0 bg-gradient-to-br from-emerald-200/50 to-slate-400" />
@@ -138,6 +141,6 @@ export default function CityCard({ city }: CityCardProps) {
           </div>
         </div>
       </div>
-    </div>
+    </Link>
   )
 }


### PR DESCRIPTION
## Summary

- `CityCard`에 `<Link>` 래핑 추가 및 좋아요/싫어요 버튼 이벤트 버블링 차단 (`stopPropagation`)
- `/cities/[id]` 동적 라우트 생성 — 없는 id 접근 시 `notFound()` 처리
- `generateStaticParams` / `generateMetadata` 적용으로 14개 도시 정적 생성 및 SEO 지원
- 상세 페이지 전용 컴포넌트 5개 신규 구현 (`city-detail/` 폴더)

## 변경 파일

| 파일 | 변경 유형 | 내용 |
|---|---|---|
| `src/components/home/CityCard.tsx` | 수정 | Link 래핑, 버튼 stopPropagation |
| `src/app/(main)/cities/[id]/page.tsx` | 신규 | 상세 페이지 라우트 |
| `src/components/city-detail/CityDetailHero.tsx` | 신규 | 그라디언트 헤더 + 도시명 + 배지 + 뒤로가기 |
| `src/components/city-detail/CityInfoGrid.tsx` | 신규 | 예산/지역/환경/계절 2×2 정보 그리드 |
| `src/components/city-detail/CityTagList.tsx` | 신규 | 도시 태그 목록 |
| `src/components/city-detail/CityScoreBar.tsx` | 신규 | 좋아요 비율 시각화 바 |
| `src/components/city-detail/RelatedCities.tsx` | 신규 | 같은 지역 추천 도시 최대 3개 |

## Test plan

- [ ] `/cities/jeju` 접근 시 제주시 상세 정보 정상 표시
- [ ] `/cities/unknown` 접근 시 404 페이지 표시
- [ ] 홈 카드 클릭 → 상세 이동 → 뒤로가기(목록으로) → 홈 복귀 흐름 정상 동작
- [ ] 같은 지역 추천 도시 카드 클릭 → 해당 도시 상세 페이지 이동
- [ ] 좋아요/싫어요 버튼 클릭 시 페이지 이동 없이 카운트만 변경
- [ ] `npx tsc --noEmit` 타입 오류 없음 ✅
- [ ] 모바일/데스크탑 반응형 UI 확인

Closes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)