### PR TITLE
[design] 도시 카드 UI 개선 - 전체 도시명/태그라인 표시 및 좋아요·싫어요 레이아웃 변경

### DIFF
--- a/src/components/home/CityCard.tsx
+++ b/src/components/home/CityCard.tsx
@@ -52,8 +52,9 @@ export default function CityCard({ city }: CityCardProps) {
       {/* 이미지 영역 */}
       <div className="relative h-44 bg-gradient-to-br from-slate-300 to-slate-400 overflow-hidden">
         <div className="absolute inset-0 bg-gradient-to-br from-emerald-200/50 to-slate-400" />
-        <div className="absolute inset-0 flex items-center justify-center">
-          <span className="text-white/60 text-4xl font-bold">{city.name.charAt(0)}</span>
+        <div className="absolute inset-0 flex flex-col items-center justify-center gap-1">
+          <span className="text-white font-bold text-xl drop-shadow">{city.name}</span>
+          <span className="text-white/80 text-xs">{city.tagline}</span>
         </div>
         {city.badge && (
           <div className="absolute top-3 left-3">
@@ -66,39 +67,34 @@ export default function CityCard({ city }: CityCardProps) {
 
       {/* 콘텐츠 */}
       <div className="flex flex-col p-4">
-        {/* 도시명 + 좋아요/싫어요 */}
-        <div className="flex items-start justify-between mb-3">
-          <div>
-            <h3 className="font-bold text-slate-900 text-base">{city.name}</h3>
-          </div>
-          <div className="flex items-center gap-3">
-            <button
-              onClick={handleLike}
-              className="flex items-center gap-1"
-              aria-label="좋아요"
-            >
-              <ThumbsUp
-                className={cn(
-                  "h-4 w-4 transition-colors",
-                  liked ? "text-emerald-500 fill-emerald-500" : "text-slate-400"
-                )}
-              />
-              <span className="text-xs text-slate-500">{likeCount}</span>
-            </button>
-            <button
-              onClick={handleDislike}
-              className="flex items-center gap-1"
-              aria-label="싫어요"
-            >
-              <ThumbsDown
-                className={cn(
-                  "h-4 w-4 transition-colors",
-                  disliked ? "text-rose-500 fill-rose-500" : "text-slate-400"
-                )}
-              />
-              <span className="text-xs text-slate-500">{dislikeCount}</span>
-            </button>
-          </div>
+        {/* 좋아요/싫어요 */}
+        <div className="flex items-center justify-between mb-3">
+          <button
+            onClick={handleLike}
+            className="flex items-center gap-1"
+            aria-label="좋아요"
+          >
+            <ThumbsUp
+              className={cn(
+                "h-4 w-4 transition-colors",
+                liked ? "text-emerald-500 fill-emerald-500" : "text-slate-400"
+              )}
+            />
+            <span className="text-xs text-slate-500">{likeCount}</span>
+          </button>
+          <button
+            onClick={handleDislike}
+            className="flex items-center gap-1"
+            aria-label="싫어요"
+          >
+            <span className="text-xs text-slate-500">{dislikeCount}</span>
+            <ThumbsDown
+              className={cn(
+                "h-4 w-4 transition-colors",
+                disliked ? "text-rose-500 fill-rose-500" : "text-slate-400"
+              )}
+            />
+          </button>
         </div>
 
         {/* Key-Value 정보 그리드 */}

--- a/src/data/cities.ts
+++ b/src/data/cities.ts
@@ -8,6 +8,7 @@ export type SeasonType = "봄" | "여름" | "가을" | "겨울"
 export type City = {
   id: string
   name: string
+  tagline: string
   budget: BudgetType
   region: RegionType
   environment: EnvironmentType[]
@@ -24,6 +25,7 @@ export const cities: City[] = [
   {
     id: "jeju",
     name: "제주시",
+    tagline: "섬이 주는 자유",
     budget: "100~200만원",
     region: "제주도",
     environment: ["자연친화", "카페작업"],
@@ -37,6 +39,7 @@ export const cities: City[] = [
   {
     id: "seoul",
     name: "서울",
+    tagline: "모든 것이 가능한 도시",
     budget: "200만원 이상",
     region: "수도권",
     environment: ["도심선호", "코워킹 필수"],
@@ -50,6 +53,7 @@ export const cities: City[] = [
   {
     id: "busan",
     name: "부산",
+    tagline: "파도처럼 역동적인 도시",
     budget: "100~200만원",
     region: "경상도",
     environment: ["도심선호", "코워킹 필수", "자연친화"],
@@ -63,6 +67,7 @@ export const cities: City[] = [
   {
     id: "gangneung",
     name: "강릉",
+    tagline: "커피향 가득한 바닷가",
     budget: "100만원 이하",
     region: "강원도",
     environment: ["자연친화", "카페작업"],
@@ -75,6 +80,7 @@ export const cities: City[] = [
   {
     id: "seogwipo",
     name: "서귀포",
+    tagline: "느리게 살기 좋은 남쪽",
     budget: "100~200만원",
     region: "제주도",
     environment: ["자연친화"],
@@ -87,6 +93,7 @@ export const cities: City[] = [
   {
     id: "daejeon",
     name: "대전",
+    tagline: "과학과 교통의 중심",
     budget: "100만원 이하",
     region: "충청도",
     environment: ["도심선호", "코워킹 필수"],
@@ -99,6 +106,7 @@ export const cities: City[] = [
   {
     id: "jeonju",
     name: "전주",
+    tagline: "한옥 속 슬로우 라이프",
     budget: "100만원 이하",
     region: "전라도",
     environment: ["카페작업", "자연친화"],
@@ -111,6 +119,7 @@ export const cities: City[] = [
   {
     id: "chuncheon",
     name: "춘천",
+    tagline: "호수와 낭만의 도시",
     budget: "100만원 이하",
     region: "강원도",
     environment: ["자연친화"],
@@ -123,6 +132,7 @@ export const cities: City[] = [
   {
     id: "gwangju",
     name: "광주",
+    tagline: "예술과 맛의 수도",
     budget: "100만원 이하",
     region: "전라도",
     environment: ["도심선호", "카페작업"],
@@ -135,6 +145,7 @@ export const cities: City[] = [
   {
     id: "sokcho",
     name: "속초",
+    tagline: "산과 바다가 만나는 곳",
     budget: "100만원 이하",
     region: "강원도",
     environment: ["자연친화"],
@@ -147,6 +158,7 @@ export const cities: City[] = [
   {
     id: "gyeongju",
     name: "경주",
+    tagline: "천년의 고도",
     budget: "100만원 이하",
     region: "경상도",
     environment: ["자연친화", "카페작업"],
@@ -159,6 +171,7 @@ export const cities: City[] = [
   {
     id: "daegu",
     name: "대구",
+    tagline: "패션과 열정의 도시",
     budget: "100만원 이하",
     region: "경상도",
     environment: ["도심선호"],
@@ -171,6 +184,7 @@ export const cities: City[] = [
   {
     id: "yeosu",
     name: "여수",
+    tagline: "밤바다의 낭만",
     budget: "100만원 이하",
     region: "전라도",
     environment: ["자연친화", "카페작업"],
@@ -183,6 +197,7 @@ export const cities: City[] = [
   {
     id: "cheongju",
     name: "청주",
+    tagline: "실용적인 중부의 거점",
     budget: "100만원 이하",
     region: "충청도",
     environment: ["도심선호", "코워킹 필수"],


### PR DESCRIPTION
## Summary

- `City` 타입에 `tagline: string` 필드 추가 및 14개 도시 tagline 데이터 입력
- CityCard 이미지 영역: 첫 글자 → 도시 전체명(bold) + tagline(소형 텍스트) 세로 배치
- 좋아요 버튼 왼쪽(`[👍 수]`), 싫어요 버튼 오른쪽(`[수 👎]`) 분리 정렬
- 콘텐츠 영역 중복 도시명 `<h3>` 제거

## Test plan

- [ ] 이미지 영역에 도시명과 tagline이 올바르게 렌더링됨
- [ ] 좋아요 버튼 왼쪽, 싫어요 버튼 오른쪽 배치 확인
- [ ] 콘텐츠 영역 도시명 중복 제거 확인
- [ ] `npx tsc --noEmit` 통과 ✅
- [ ] 모바일/데스크탑 반응형 시각 확인

Closes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)