### PR TITLE
[design] 필터 버튼 전체 너비 균등 분배 개선 (#3)

### DIFF
--- a/src/components/home/QuickFilterBar.tsx
+++ b/src/components/home/QuickFilterBar.tsx
@@ -32,23 +32,21 @@ export default function QuickFilterBar() {
             <span className="text-xs font-medium text-slate-500 w-16 shrink-0">
               {filter.label}
             </span>
-            <div className="overflow-x-auto">
-              <div className="flex flex-nowrap gap-1">
-                {filter.options.map((option) => (
-                  <button
-                    key={option}
-                    onClick={() => setters[i](option)}
-                    className={cn(
-                      "px-3 py-1.5 rounded-full text-sm font-medium whitespace-nowrap transition-colors",
-                      activeValues[i] === option
-                        ? "bg-slate-800 text-white"
-                        : "bg-slate-100 text-slate-600 hover:bg-slate-200"
-                    )}
-                  >
-                    {option}
-                  </button>
-                ))}
-              </div>
+            <div className="flex w-full gap-1">
+              {filter.options.map((option) => (
+                <button
+                  key={option}
+                  onClick={() => setters[i](option)}
+                  className={cn(
+                    "flex-1 py-1.5 rounded-full text-sm font-medium text-center transition-colors",
+                    activeValues[i] === option
+                      ? "bg-slate-800 text-white"
+                      : "bg-slate-100 text-slate-600 hover:bg-slate-200"
+                  )}
+                >
+                  {option}
+                </button>
+              ))}
             </div>
           </div>
         ))}


### PR DESCRIPTION
## Summary

- `overflow-x-auto` 스크롤 래퍼 및 `flex-nowrap` 중첩 div 제거
- 버튼 컨테이너를 `flex w-full gap-1`로 단순화
- 각 버튼에 `flex-1 text-center` 적용하여 행 너비 균등 분배
- `px-3`, `whitespace-nowrap` 제거

## 변경 파일

- `src/components/home/QuickFilterBar.tsx`

## Test plan

- [ ] 예산(4개) / 지역(7개) / 환경(5개) / 계절(5개) 버튼이 각 행을 꽉 채우는지 확인
- [ ] 활성/비활성 스타일(slate-800 / slate-100) 정상 동작 확인
- [ ] 데스크탑(1280px) 레이아웃 확인
- [ ] 모바일(375px) 레이아웃 확인 — 가로 스크롤 없이 균등 표시
- [ ] `npx tsc --noEmit` 타입 오류 없음

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)